### PR TITLE
Add synth and effects controls to Sequence Lab

### DIFF
--- a/sequence-lab/sequencer.css
+++ b/sequence-lab/sequencer.css
@@ -68,12 +68,85 @@ body {
   gap: 18px;
 }
 
+.panel.sequencer {
+  grid-column: 1 / -1;
+  gap: 16px;
+}
+
 .panel h2 {
   margin: 0;
   font-size: 0.95rem;
   letter-spacing: 0.2rem;
   text-transform: uppercase;
   color: var(--text-muted);
+}
+
+.sequencer-note {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.sequencer-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.sequencer-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.sequencer-label {
+  width: 64px;
+  font-size: 0.75rem;
+  letter-spacing: 0.2rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.steps {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(16, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.step {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.4));
+  border-radius: 8px;
+  height: 34px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease,
+    transform 0.1s ease;
+}
+
+.step:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.step:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.step.step--beat {
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.step.active {
+  background: linear-gradient(180deg, var(--accent), #1f6f95);
+  border-color: rgba(109, 207, 246, 0.7);
+  box-shadow: 0 10px 24px rgba(109, 207, 246, 0.25);
+}
+
+.step.playing {
+  box-shadow: inset 0 0 0 2px var(--accent-strong), 0 0 16px rgba(255, 143, 112, 0.35);
 }
 
 .transport-controls {
@@ -259,5 +332,19 @@ input[type="range"]::-moz-range-thumb {
 
   .control-inline .value {
     justify-self: end;
+  }
+
+  .sequencer-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .sequencer-label {
+    width: 100%;
+  }
+
+  .steps {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
   }
 }

--- a/sequence-lab/sequencer.css
+++ b/sequence-lab/sequencer.css
@@ -1,0 +1,263 @@
+:root {
+  --bg: #0b0d11;
+  --panel: #1c1f27;
+  --panel-edge: #101218;
+  --text: #f7f8fb;
+  --text-muted: #9aa2b4;
+  --accent: #6dcff6;
+  --accent-strong: #ff8f70;
+  --border: rgba(255, 255, 255, 0.06);
+  --shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  --radius: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at 20% 10%, #161921 0%, #0b0d11 60%);
+  min-height: 100%;
+}
+
+.layout {
+  max-width: 1200px;
+  margin: 48px auto;
+  padding: 0 28px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.masthead {
+  text-align: center;
+}
+
+.brand {
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: 0.3rem;
+  text-transform: uppercase;
+}
+
+.tagline {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.panel {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(0, 0, 0, 0.4)), var(--panel);
+  border-radius: var(--radius);
+  padding: 20px 22px;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.2rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.transport-controls {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.btn {
+  appearance: none;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #ffffff, #cfd4d8);
+  color: #111;
+  font-weight: 600;
+  padding: 10px 20px;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn:not(:disabled):active {
+  transform: translateY(1px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+}
+
+.status {
+  margin-left: auto;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 14px;
+  padding: 14px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.control--toggle {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.control-inline {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  min-width: 220px;
+}
+
+.control label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1rem;
+  color: var(--text-muted);
+}
+
+.value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  min-width: 72px;
+  text-align: right;
+}
+
+input[type="range"] {
+  width: 100%;
+  appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.05));
+  outline: none;
+  position: relative;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #fff, #d7dbe0 60%, #a8adb4);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+  border: none;
+  cursor: pointer;
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #fff, #d7dbe0 60%, #a8adb4);
+  border: none;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12rem;
+}
+
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.toggle-visual {
+  width: 52px;
+  height: 26px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #383c44, #1b1d22);
+  position: relative;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.6), 0 6px 12px rgba(0, 0, 0, 0.35);
+  transition: background 0.2s ease;
+}
+
+.toggle-visual::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #fff, #e0e3e9 60%, #a8adb4);
+  transition: transform 0.2s ease;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.35);
+}
+
+.toggle input:checked + .toggle-visual {
+  background: linear-gradient(180deg, var(--accent), #1f6f95);
+}
+
+.toggle input:checked + .toggle-visual::after {
+  transform: translateX(26px);
+}
+
+.toggle-label {
+  color: var(--text);
+}
+
+.subheading {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18rem;
+  color: var(--accent);
+}
+
+.drone {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+@media (max-width: 720px) {
+  .control--toggle {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .control-inline {
+    width: 100%;
+    grid-template-columns: auto 1fr;
+  }
+
+  .control-inline .value {
+    justify-self: end;
+  }
+}

--- a/sequence-lab/sequencer.html
+++ b/sequence-lab/sequencer.html
@@ -14,6 +14,15 @@
     </header>
 
     <section class="panels">
+      <section class="panel sequencer" aria-labelledby="sequencer-title">
+        <h2 id="sequencer-title">Step Sequencer</h2>
+        <p class="sequencer-note">
+          Tap steps to build 16-part patterns. Active pads glow and the playhead sweep highlights the
+          current column as the groove rolls.
+        </p>
+        <div class="sequencer-grid" id="sequencer-grid" role="grid" aria-label="16 step sequencer"></div>
+      </section>
+
       <section class="panel transport" aria-labelledby="transport-title">
         <h2 id="transport-title">Transport</h2>
         <div class="transport-controls">

--- a/sequence-lab/sequencer.html
+++ b/sequence-lab/sequencer.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sequence Lab – Live Set Sketchpad</title>
+  <link rel="stylesheet" href="sequencer.css" />
+</head>
+<body>
+  <main class="layout">
+    <header class="masthead">
+      <div class="brand">Sequence Lab</div>
+      <p class="tagline">Polyrythmic sketches, drones &amp; bass in one view.</p>
+    </header>
+
+    <section class="panels">
+      <section class="panel transport" aria-labelledby="transport-title">
+        <h2 id="transport-title">Transport</h2>
+        <div class="transport-controls">
+          <button id="start" class="btn">Start</button>
+          <button id="stop" class="btn" disabled>Stop</button>
+          <div class="status" id="status">Idle</div>
+        </div>
+      </section>
+
+      <section class="panel clock" aria-labelledby="clock-title">
+        <h2 id="clock-title">Clock &amp; Swing</h2>
+        <div class="control">
+          <label for="tempo">Tempo <span class="value" id="tempo-value">120 BPM</span></label>
+          <input type="range" id="tempo" min="60" max="200" value="120" />
+        </div>
+        <div class="control">
+          <label for="swing">Swing <span class="value" id="swing-value">0%</span></label>
+          <input type="range" id="swing" min="0" max="100" value="0" />
+        </div>
+      </section>
+
+      <section class="panel fx" aria-labelledby="fx-title">
+        <h2 id="fx-title">Master FX</h2>
+        <div class="control control--toggle">
+          <label class="toggle">
+            <input type="checkbox" id="delay-toggle" checked />
+            <span class="toggle-visual"></span>
+            <span class="toggle-label">Delay</span>
+          </label>
+          <div class="control-inline">
+            <label for="delay-time">Time</label>
+            <input type="range" id="delay-time" min="80" max="1200" value="320" />
+            <span class="value" id="delay-time-value">320 ms</span>
+          </div>
+        </div>
+        <div class="control control--toggle">
+          <label class="toggle">
+            <input type="checkbox" id="highpass-toggle" />
+            <span class="toggle-visual"></span>
+            <span class="toggle-label">High-pass</span>
+          </label>
+          <div class="control-inline">
+            <label for="highpass-cutoff">Cutoff</label>
+            <input type="range" id="highpass-cutoff" min="20" max="1000" value="200" />
+            <span class="value" id="highpass-cutoff-value">200 Hz</span>
+          </div>
+        </div>
+        <div class="control control--toggle">
+          <label class="toggle">
+            <input type="checkbox" id="lowpass-toggle" checked />
+            <span class="toggle-visual"></span>
+            <span class="toggle-label">Low-pass</span>
+          </label>
+          <div class="control-inline">
+            <label for="lowpass-cutoff">Cutoff</label>
+            <input type="range" id="lowpass-cutoff" min="500" max="12000" value="6000" />
+            <span class="value" id="lowpass-cutoff-value">6,000 Hz</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel synth" aria-labelledby="synth-title">
+        <h2 id="synth-title">Synth &amp; Atmosphere</h2>
+        <div class="subheading">Random Bass</div>
+        <div class="control control--toggle">
+          <label class="toggle">
+            <input type="checkbox" id="bass-toggle" />
+            <span class="toggle-visual"></span>
+            <span class="toggle-label">Enable</span>
+          </label>
+          <div class="control-inline">
+            <label for="bass-chance">Chance</label>
+            <input type="range" id="bass-chance" min="0" max="100" value="40" />
+            <span class="value" id="bass-chance-value">40%</span>
+          </div>
+        </div>
+
+        <div class="subheading">Drones</div>
+        <div class="drone" data-drone="1">
+          <div class="control control--toggle">
+            <label class="toggle">
+              <input type="checkbox" id="drone1-toggle" />
+              <span class="toggle-visual"></span>
+              <span class="toggle-label">Drone 1</span>
+            </label>
+            <div class="control-inline">
+              <label for="drone1-frequency">Freq</label>
+              <input type="range" id="drone1-frequency" min="40" max="320" value="110" />
+              <span class="value" id="drone1-frequency-value">110 Hz</span>
+            </div>
+          </div>
+        </div>
+        <div class="drone" data-drone="2">
+          <div class="control control--toggle">
+            <label class="toggle">
+              <input type="checkbox" id="drone2-toggle" />
+              <span class="toggle-visual"></span>
+              <span class="toggle-label">Drone 2</span>
+            </label>
+            <div class="control-inline">
+              <label for="drone2-frequency">Freq</label>
+              <input type="range" id="drone2-frequency" min="80" max="520" value="220" />
+              <span class="value" id="drone2-frequency-value">220 Hz</span>
+            </div>
+          </div>
+        </div>
+        <div class="drone" data-drone="3">
+          <div class="control control--toggle">
+            <label class="toggle">
+              <input type="checkbox" id="drone3-toggle" />
+              <span class="toggle-visual"></span>
+              <span class="toggle-label">Drone 3</span>
+            </label>
+            <div class="control-inline">
+              <label for="drone3-frequency">Freq</label>
+              <input type="range" id="drone3-frequency" min="120" max="780" value="330" />
+              <span class="value" id="drone3-frequency-value">330 Hz</span>
+            </div>
+          </div>
+        </div>
+      </section>
+    </section>
+  </main>
+
+  <script src="sequencer.js" defer></script>
+</body>
+</html>

--- a/sequence-lab/sequencer.js
+++ b/sequence-lab/sequencer.js
@@ -2,6 +2,7 @@
   const startButton = document.getElementById('start');
   const stopButton = document.getElementById('stop');
   const statusLabel = document.getElementById('status');
+  const sequencerGrid = document.getElementById('sequencer-grid');
 
   const tempoSlider = document.getElementById('tempo');
   const tempoValue = document.getElementById('tempo-value');
@@ -48,6 +49,25 @@
     }
   ];
 
+  const stepCount = 16;
+  const voiceDefinitions = [
+    { id: 'kick', label: 'Kick' },
+    { id: 'snare', label: 'Snare' },
+    { id: 'hat', label: 'Hat' }
+  ];
+
+  const defaultPatterns = {
+    kick: [0, 8],
+    snare: [4, 12],
+    hat: Array.from({ length: stepCount }, (_, index) => (index % 2 === 0 ? index : null)).filter(
+      (index) => index !== null
+    )
+  };
+
+  const sequenceState = new Map();
+  const stepElements = new Map();
+  let playheadStep = -1;
+
   let audioCtx;
   let masterInput;
   let masterGain;
@@ -57,6 +77,9 @@
   let delayFeedback;
   let delaySend;
   let delayWet;
+
+  let snareNoiseBuffer;
+  let hatNoiseBuffer;
 
   let isPlaying = false;
   let schedulerId;
@@ -135,6 +158,230 @@
     node.connect(masterInput);
   }
 
+  function cleanupNodes(...nodes) {
+    nodes.forEach((node) => {
+      if (!node) return;
+      try {
+        node.disconnect();
+      } catch (err) {
+        // ignored
+      }
+    });
+  }
+
+  function createNoiseBuffer(ctx, durationSeconds) {
+    const length = Math.max(1, Math.floor(ctx.sampleRate * durationSeconds));
+    const buffer = ctx.createBuffer(1, length, ctx.sampleRate);
+    const data = buffer.getChannelData(0);
+    for (let i = 0; i < length; i += 1) {
+      data[i] = Math.random() * 2 - 1;
+    }
+    return buffer;
+  }
+
+  function getSnareNoiseBuffer(ctx) {
+    if (!snareNoiseBuffer) {
+      snareNoiseBuffer = createNoiseBuffer(ctx, 0.25);
+    }
+    return snareNoiseBuffer;
+  }
+
+  function getHatNoiseBuffer(ctx) {
+    if (!hatNoiseBuffer) {
+      hatNoiseBuffer = createNoiseBuffer(ctx, 0.08);
+    }
+    return hatNoiseBuffer;
+  }
+
+  function applyStepState(voiceId, stepIndex, state) {
+    const pattern = sequenceState.get(voiceId);
+    if (!pattern) return;
+    pattern[stepIndex] = Boolean(state);
+    const buttons = stepElements.get(voiceId);
+    const button = buttons ? buttons[stepIndex] : undefined;
+    if (!button) return;
+    button.classList.toggle('active', pattern[stepIndex]);
+    button.setAttribute('aria-pressed', pattern[stepIndex] ? 'true' : 'false');
+  }
+
+  function toggleStep(voiceId, stepIndex) {
+    const pattern = sequenceState.get(voiceId);
+    if (!pattern) return;
+    const nextState = !pattern[stepIndex];
+    applyStepState(voiceId, stepIndex, nextState);
+  }
+
+  function updatePlayhead(stepIndex) {
+    if (playheadStep === stepIndex) {
+      return;
+    }
+    stepElements.forEach((buttons) => {
+      buttons.forEach((button, index) => {
+        button.classList.toggle('playing', stepIndex === index);
+      });
+    });
+    playheadStep = stepIndex;
+  }
+
+  function createSequencerGrid() {
+    if (!sequencerGrid) return;
+    sequencerGrid.textContent = '';
+
+    voiceDefinitions.forEach((voice) => {
+      const pattern = new Array(stepCount).fill(false);
+      sequenceState.set(voice.id, pattern);
+
+      const row = document.createElement('div');
+      row.className = 'sequencer-row';
+      row.setAttribute('role', 'row');
+
+      const label = document.createElement('span');
+      label.className = 'sequencer-label';
+      label.textContent = voice.label;
+      label.setAttribute('role', 'rowheader');
+      row.appendChild(label);
+
+      const stepsWrapper = document.createElement('div');
+      stepsWrapper.className = 'steps';
+      stepsWrapper.setAttribute('role', 'presentation');
+
+      const buttons = [];
+      for (let i = 0; i < stepCount; i += 1) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'step';
+        if (i % 4 === 0) {
+          button.classList.add('step--beat');
+        }
+        button.dataset.voice = voice.id;
+        button.dataset.step = String(i);
+        button.setAttribute('aria-label', `${voice.label} step ${i + 1}`);
+        button.setAttribute('aria-pressed', 'false');
+        button.setAttribute('role', 'gridcell');
+        button.addEventListener('click', () => toggleStep(voice.id, i));
+        stepsWrapper.appendChild(button);
+        buttons.push(button);
+      }
+
+      stepElements.set(voice.id, buttons);
+
+      const defaults = defaultPatterns[voice.id] || [];
+      defaults.forEach((index) => {
+        if (typeof index === 'number' && index >= 0 && index < stepCount) {
+          applyStepState(voice.id, index, true);
+        }
+      });
+
+      row.appendChild(stepsWrapper);
+      sequencerGrid.appendChild(row);
+    });
+  }
+
+  function playKick(time) {
+    ensureAudio();
+    if (!audioCtx) return;
+
+    const osc = audioCtx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(140, time);
+    osc.frequency.exponentialRampToValueAtTime(50, time + 0.25);
+
+    const gain = audioCtx.createGain();
+    gain.gain.setValueAtTime(1.0, time);
+    gain.gain.exponentialRampToValueAtTime(0.001, time + 0.5);
+
+    osc.connect(gain);
+    connectVoice(gain);
+
+    osc.start(time);
+    osc.stop(time + 0.5);
+    osc.onended = () => {
+      cleanupNodes(osc, gain);
+    };
+  }
+
+  function playSnare(time) {
+    ensureAudio();
+    if (!audioCtx) return;
+
+    const noiseSource = audioCtx.createBufferSource();
+    noiseSource.buffer = getSnareNoiseBuffer(audioCtx);
+
+    const noiseFilter = audioCtx.createBiquadFilter();
+    noiseFilter.type = 'highpass';
+    noiseFilter.frequency.value = 1200;
+
+    const noiseGain = audioCtx.createGain();
+    noiseGain.gain.setValueAtTime(0.5, time);
+    noiseGain.gain.exponentialRampToValueAtTime(0.001, time + 0.25);
+
+    noiseSource.connect(noiseFilter);
+    noiseFilter.connect(noiseGain);
+    connectVoice(noiseGain);
+
+    noiseSource.start(time);
+    noiseSource.stop(time + 0.3);
+    noiseSource.onended = () => {
+      cleanupNodes(noiseSource, noiseFilter, noiseGain);
+    };
+
+    const tone = audioCtx.createOscillator();
+    tone.type = 'triangle';
+    tone.frequency.setValueAtTime(200, time);
+    tone.frequency.exponentialRampToValueAtTime(120, time + 0.18);
+
+    const toneGain = audioCtx.createGain();
+    toneGain.gain.setValueAtTime(0.2, time);
+    toneGain.gain.exponentialRampToValueAtTime(0.001, time + 0.2);
+
+    tone.connect(toneGain);
+    connectVoice(toneGain);
+
+    tone.start(time);
+    tone.stop(time + 0.22);
+    tone.onended = () => {
+      cleanupNodes(tone, toneGain);
+    };
+  }
+
+  function playHat(time) {
+    ensureAudio();
+    if (!audioCtx) return;
+
+    const noiseSource = audioCtx.createBufferSource();
+    noiseSource.buffer = getHatNoiseBuffer(audioCtx);
+
+    const bandpass = audioCtx.createBiquadFilter();
+    bandpass.type = 'bandpass';
+    bandpass.frequency.value = 9000;
+    bandpass.Q.value = 8;
+
+    const highpass = audioCtx.createBiquadFilter();
+    highpass.type = 'highpass';
+    highpass.frequency.value = 7000;
+
+    const gain = audioCtx.createGain();
+    gain.gain.setValueAtTime(0.18, time);
+    gain.gain.exponentialRampToValueAtTime(0.001, time + 0.08);
+
+    noiseSource.connect(bandpass);
+    bandpass.connect(highpass);
+    highpass.connect(gain);
+    connectVoice(gain);
+
+    noiseSource.start(time);
+    noiseSource.stop(time + 0.12);
+    noiseSource.onended = () => {
+      cleanupNodes(noiseSource, bandpass, highpass, gain);
+    };
+  }
+
+  const voicePlayers = {
+    kick: playKick,
+    snare: playSnare,
+    hat: playHat
+  };
+
   function playBass(time) {
     if (!audioCtx || !isRandomBassEnabled) return;
     if (Math.random() * 100 >= bassChance) return;
@@ -177,6 +424,20 @@
   }
 
   function scheduleStep() {
+    const stepIndex = currentStep;
+    updatePlayhead(stepIndex);
+
+    voiceDefinitions.forEach((voice) => {
+      const pattern = sequenceState.get(voice.id);
+      if (!pattern || !pattern[stepIndex]) {
+        return;
+      }
+      const player = voicePlayers[voice.id];
+      if (player) {
+        player(nextNoteTime);
+      }
+    });
+
     playBass(nextNoteTime);
   }
 
@@ -206,6 +467,7 @@
 
     nextNoteTime = audioCtx.currentTime + 0.05;
     currentStep = 0;
+    updatePlayhead(-1);
 
     scheduler();
     startEnabledDrones();
@@ -219,6 +481,9 @@
     statusLabel.textContent = 'Stopped';
     startButton.disabled = false;
     stopButton.disabled = true;
+
+    updatePlayhead(-1);
+    currentStep = 0;
 
     stopAllDrones();
   }
@@ -321,6 +586,9 @@
     bassChance = Number(bassChanceSlider.value);
     bassChanceValue.textContent = `${bassChance}%`;
   }
+
+  createSequencerGrid();
+  updatePlayhead(-1);
 
   startButton.addEventListener('click', startSequencer);
   stopButton.addEventListener('click', stopSequencer);

--- a/sequence-lab/sequencer.js
+++ b/sequence-lab/sequencer.js
@@ -1,0 +1,391 @@
+(() => {
+  const startButton = document.getElementById('start');
+  const stopButton = document.getElementById('stop');
+  const statusLabel = document.getElementById('status');
+
+  const tempoSlider = document.getElementById('tempo');
+  const tempoValue = document.getElementById('tempo-value');
+  const swingSlider = document.getElementById('swing');
+  const swingValue = document.getElementById('swing-value');
+
+  const delayToggle = document.getElementById('delay-toggle');
+  const delayTimeSlider = document.getElementById('delay-time');
+  const delayTimeValue = document.getElementById('delay-time-value');
+
+  const highpassToggle = document.getElementById('highpass-toggle');
+  const highpassCutoffSlider = document.getElementById('highpass-cutoff');
+  const highpassCutoffValue = document.getElementById('highpass-cutoff-value');
+
+  const lowpassToggle = document.getElementById('lowpass-toggle');
+  const lowpassCutoffSlider = document.getElementById('lowpass-cutoff');
+  const lowpassCutoffValue = document.getElementById('lowpass-cutoff-value');
+
+  const bassToggle = document.getElementById('bass-toggle');
+  const bassChanceSlider = document.getElementById('bass-chance');
+  const bassChanceValue = document.getElementById('bass-chance-value');
+
+  const droneConfigs = [
+    {
+      toggle: document.getElementById('drone1-toggle'),
+      slider: document.getElementById('drone1-frequency'),
+      value: document.getElementById('drone1-frequency-value'),
+      detuneRatio: 1.005,
+      gain: 0.1
+    },
+    {
+      toggle: document.getElementById('drone2-toggle'),
+      slider: document.getElementById('drone2-frequency'),
+      value: document.getElementById('drone2-frequency-value'),
+      detuneRatio: 1.007,
+      gain: 0.12
+    },
+    {
+      toggle: document.getElementById('drone3-toggle'),
+      slider: document.getElementById('drone3-frequency'),
+      value: document.getElementById('drone3-frequency-value'),
+      detuneRatio: 1.009,
+      gain: 0.14
+    }
+  ];
+
+  let audioCtx;
+  let masterInput;
+  let masterGain;
+  let highpassFilter;
+  let lowpassFilter;
+  let delayNode;
+  let delayFeedback;
+  let delaySend;
+  let delayWet;
+
+  let isPlaying = false;
+  let schedulerId;
+  let nextNoteTime = 0;
+  let currentStep = 0;
+
+  const lookahead = 25;
+  const scheduleAheadTime = 0.1;
+
+  let isRandomBassEnabled = bassToggle.checked;
+  let bassChance = Number(bassChanceSlider.value);
+
+  const cMajorNotes = [
+    65.41, 73.42, 82.41, 87.31, 98.0, 110.0, 123.47, 130.81, 146.83, 164.81,
+    174.61, 196.0, 220.0, 246.94, 261.63
+  ];
+
+  const droneState = new WeakMap();
+
+  function ensureAudio() {
+    if (audioCtx) {
+      return audioCtx;
+    }
+
+    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
+    masterInput = audioCtx.createGain();
+    masterInput.gain.value = 1;
+
+    highpassFilter = audioCtx.createBiquadFilter();
+    highpassFilter.type = 'highpass';
+    highpassFilter.frequency.value = highpassToggle.checked
+      ? Number(highpassCutoffSlider.value)
+      : 20;
+
+    lowpassFilter = audioCtx.createBiquadFilter();
+    lowpassFilter.type = 'lowpass';
+    lowpassFilter.frequency.value = lowpassToggle.checked
+      ? Number(lowpassCutoffSlider.value)
+      : audioCtx.sampleRate / 2;
+
+    masterGain = audioCtx.createGain();
+    masterGain.gain.value = 0.7;
+
+    delayNode = audioCtx.createDelay(1.5);
+    delayNode.delayTime.value = Number(delayTimeSlider.value) / 1000;
+
+    delayFeedback = audioCtx.createGain();
+    delayFeedback.gain.value = 0.32;
+
+    delayWet = audioCtx.createGain();
+    delayWet.gain.value = 0.35;
+
+    delaySend = audioCtx.createGain();
+    delaySend.gain.value = delayToggle.checked ? 0.35 : 0;
+
+    masterInput.connect(highpassFilter);
+    highpassFilter.connect(lowpassFilter);
+    lowpassFilter.connect(masterGain);
+    masterGain.connect(audioCtx.destination);
+
+    masterInput.connect(delaySend);
+    delaySend.connect(delayNode);
+    delayNode.connect(delayFeedback);
+    delayFeedback.connect(delayNode);
+    delayNode.connect(delayWet);
+    delayWet.connect(masterGain);
+
+    return audioCtx;
+  }
+
+  function connectVoice(node) {
+    if (!masterInput) {
+      ensureAudio();
+    }
+    node.connect(masterInput);
+  }
+
+  function playBass(time) {
+    if (!audioCtx || !isRandomBassEnabled) return;
+    if (Math.random() * 100 >= bassChance) return;
+
+    const index = Math.floor(Math.random() * cMajorNotes.length);
+    const frequency = cMajorNotes[index];
+
+    const osc = audioCtx.createOscillator();
+    osc.type = 'sawtooth';
+    osc.frequency.setValueAtTime(frequency, time);
+
+    const gain = audioCtx.createGain();
+    gain.gain.setValueAtTime(0.16, time);
+    gain.gain.exponentialRampToValueAtTime(0.001, time + 1.1);
+
+    osc.connect(gain);
+    connectVoice(gain);
+
+    osc.start(time);
+    osc.stop(time + 1.2);
+
+    osc.onended = () => {
+      osc.disconnect();
+      gain.disconnect();
+    };
+  }
+
+  function nextNote() {
+    const tempo = Number(tempoSlider.value);
+    const secondsPerBeat = 60 / tempo;
+    const swingPercent = Number(swingSlider.value) / 100;
+
+    nextNoteTime += 0.25 * secondsPerBeat;
+
+    if (currentStep % 2 === 1) {
+      nextNoteTime += swingPercent * (secondsPerBeat / 2);
+    }
+
+    currentStep = (currentStep + 1) % 16;
+  }
+
+  function scheduleStep() {
+    playBass(nextNoteTime);
+  }
+
+  function scheduler() {
+    if (!audioCtx) return;
+    while (nextNoteTime < audioCtx.currentTime + scheduleAheadTime) {
+      scheduleStep();
+      nextNote();
+    }
+    schedulerId = window.setTimeout(scheduler, lookahead);
+  }
+
+  function startSequencer() {
+    ensureAudio();
+    if (!audioCtx) return;
+
+    if (audioCtx.state === 'suspended') {
+      audioCtx.resume();
+    }
+
+    if (isPlaying) return;
+
+    isPlaying = true;
+    statusLabel.textContent = 'Playing';
+    startButton.disabled = true;
+    stopButton.disabled = false;
+
+    nextNoteTime = audioCtx.currentTime + 0.05;
+    currentStep = 0;
+
+    scheduler();
+    startEnabledDrones();
+  }
+
+  function stopSequencer() {
+    if (!isPlaying) return;
+    isPlaying = false;
+
+    window.clearTimeout(schedulerId);
+    statusLabel.textContent = 'Stopped';
+    startButton.disabled = false;
+    stopButton.disabled = true;
+
+    stopAllDrones();
+  }
+
+  function startEnabledDrones() {
+    droneConfigs.forEach((config) => {
+      if (config.toggle.checked) {
+        startDrone(config);
+      }
+    });
+  }
+
+  function stopAllDrones() {
+    droneConfigs.forEach((config) => stopDrone(config));
+  }
+
+  function startDrone(config) {
+    ensureAudio();
+    if (!audioCtx) return;
+
+    const state = droneState.get(config) || {};
+    if (state.osc1 || state.osc2) return;
+
+    const baseFrequency = Number(config.slider.value);
+
+    const osc1 = audioCtx.createOscillator();
+    osc1.type = 'sine';
+    osc1.frequency.setValueAtTime(baseFrequency, audioCtx.currentTime);
+
+    const osc2 = audioCtx.createOscillator();
+    osc2.type = 'sine';
+    osc2.frequency.setValueAtTime(baseFrequency * config.detuneRatio, audioCtx.currentTime);
+
+    const gain = audioCtx.createGain();
+    gain.gain.value = config.gain;
+
+    osc1.connect(gain);
+    osc2.connect(gain);
+    connectVoice(gain);
+
+    osc1.start();
+    osc2.start();
+
+    droneState.set(config, { osc1, osc2, gain });
+  }
+
+  function stopDrone(config) {
+    const state = droneState.get(config);
+    if (!state) return;
+
+    ['osc1', 'osc2'].forEach((key) => {
+      const osc = state[key];
+      if (!osc) return;
+      try {
+        osc.stop();
+      } catch (err) {
+        // ignore state errors
+      }
+      osc.disconnect();
+      state[key] = null;
+    });
+
+    if (state.gain) {
+      state.gain.disconnect();
+      state.gain = null;
+    }
+
+    droneState.delete(config);
+  }
+
+  function updateDroneFrequency(config) {
+    const state = droneState.get(config);
+    config.value.textContent = `${Math.round(Number(config.slider.value))} Hz`;
+    if (!state) return;
+    const baseFrequency = Number(config.slider.value);
+    state.osc1.frequency.setTargetAtTime(baseFrequency, audioCtx.currentTime, 0.05);
+    state.osc2.frequency.setTargetAtTime(baseFrequency * config.detuneRatio, audioCtx.currentTime, 0.05);
+  }
+
+  function updateDelayState() {
+    if (!audioCtx || !delayNode || !delaySend) return;
+    delaySend.gain.setTargetAtTime(delayToggle.checked ? 0.35 : 0.0, audioCtx.currentTime, 0.05);
+    delayNode.delayTime.setTargetAtTime(Number(delayTimeSlider.value) / 1000, audioCtx.currentTime, 0.05);
+  }
+
+  function updateFilterState() {
+    if (!audioCtx) return;
+    if (highpassFilter) {
+      const target = highpassToggle.checked ? Number(highpassCutoffSlider.value) : 20;
+      highpassFilter.frequency.setTargetAtTime(target, audioCtx.currentTime, 0.05);
+    }
+    if (lowpassFilter) {
+      const maxFrequency = audioCtx.sampleRate / 2;
+      const target = lowpassToggle.checked ? Number(lowpassCutoffSlider.value) : maxFrequency;
+      lowpassFilter.frequency.setTargetAtTime(target, audioCtx.currentTime, 0.05);
+    }
+  }
+
+  function updateBassChance() {
+    bassChance = Number(bassChanceSlider.value);
+    bassChanceValue.textContent = `${bassChance}%`;
+  }
+
+  startButton.addEventListener('click', startSequencer);
+  stopButton.addEventListener('click', stopSequencer);
+
+  tempoSlider.addEventListener('input', () => {
+    tempoValue.textContent = `${tempoSlider.value} BPM`;
+  });
+
+  swingSlider.addEventListener('input', () => {
+    swingValue.textContent = `${swingSlider.value}%`;
+  });
+
+  delayTimeSlider.addEventListener('input', () => {
+    delayTimeValue.textContent = `${delayTimeSlider.value} ms`;
+    updateDelayState();
+  });
+  delayToggle.addEventListener('change', () => {
+    updateDelayState();
+  });
+
+  highpassCutoffSlider.addEventListener('input', () => {
+    highpassCutoffValue.textContent = `${highpassCutoffSlider.value} Hz`;
+    updateFilterState();
+  });
+  highpassToggle.addEventListener('change', updateFilterState);
+
+  lowpassCutoffSlider.addEventListener('input', () => {
+    const value = Number(lowpassCutoffSlider.value);
+    lowpassCutoffValue.textContent = `${value.toLocaleString()} Hz`;
+    updateFilterState();
+  });
+  lowpassToggle.addEventListener('change', updateFilterState);
+
+  bassToggle.addEventListener('change', () => {
+    isRandomBassEnabled = bassToggle.checked;
+  });
+
+  bassChanceSlider.addEventListener('input', () => {
+    updateBassChance();
+  });
+
+  droneConfigs.forEach((config) => {
+    config.value.textContent = `${Math.round(Number(config.slider.value))} Hz`;
+    config.slider.addEventListener('input', () => updateDroneFrequency(config));
+    config.toggle.addEventListener('change', () => {
+      if (config.toggle.checked) {
+        if (isPlaying) {
+          startDrone(config);
+        }
+      } else {
+        stopDrone(config);
+      }
+    });
+  });
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      stopSequencer();
+    }
+  });
+
+  updateBassChance();
+  delayTimeValue.textContent = `${delayTimeSlider.value} ms`;
+  highpassCutoffValue.textContent = `${highpassCutoffSlider.value} Hz`;
+  lowpassCutoffValue.textContent = `${Number(lowpassCutoffSlider.value).toLocaleString()} Hz`;
+  tempoValue.textContent = `${tempoSlider.value} BPM`;
+  swingValue.textContent = `${swingSlider.value}%`;
+})();


### PR DESCRIPTION
## Summary
- add a Sequence Lab layout with dedicated Synth & Atmosphere controls for bass chance and drones
- style the new panel and controls to match the existing skeuomorphic aesthetic
- implement audio routing with random bass sequencing, drone oscillators, and shared master delay and filter nodes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6903923c2ba48326818a43fc60bbfbb9